### PR TITLE
Fix handling of multiple ZMQ identifiers

### DIFF
--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -14,5 +14,5 @@ namespace Litipk\JupyterPHP\Actions;
 
 interface Action
 {
-    public function call(array $header, array $content, $zmqId = null);
+    public function call(array $header, array $content, $zmqIds = []);
 }

--- a/src/Actions/ExecuteAction.php
+++ b/src/Actions/ExecuteAction.php
@@ -57,7 +57,7 @@ final class ExecuteAction implements Action
         $this->shellSoul = $shellSoul;
     }
 
-    public function call(array $header, array $content, $zmqId = null)
+    public function call(array $header, array $content, $zmqIds = [])
     {
         $this->broker->send($this->iopubSocket, 'status', ['execution_state' => 'busy'], $header);
 
@@ -85,7 +85,7 @@ final class ExecuteAction implements Action
             'user_expressions' => new \stdClass
         ];
 
-        $this->broker->send($this->shellSocket, 'execute_reply', $replyContent, $this->header, [], $zmqId);
+        $this->broker->send($this->shellSocket, 'execute_reply', $replyContent, $this->header, [], $zmqIds);
 
         $this->broker->send($this->iopubSocket, 'status', ['execution_state' => 'idle'], $this->header);
     }

--- a/src/Actions/HistoryAction.php
+++ b/src/Actions/HistoryAction.php
@@ -31,8 +31,8 @@ final class HistoryAction implements Action
         $this->shellSocket = $shellSocket;
     }
 
-    public function call(array $header, array $content, $zmqId = null)
+    public function call(array $header, array $content, $zmqIds = [])
     {
-        $this->broker->send($this->shellSocket, 'history_reply', ['history' => []], $header, [], $zmqId);
+        $this->broker->send($this->shellSocket, 'history_reply', ['history' => []], $header, [], $zmqIds);
     }
 }

--- a/src/Actions/KernelInfoAction.php
+++ b/src/Actions/KernelInfoAction.php
@@ -33,7 +33,7 @@ final class KernelInfoAction implements Action
         $this->iopubSocket = $iopubSocket;
     }
 
-    public function call(array $header, array $content, $zmqId = null)
+    public function call(array $header, array $content, $zmqIds = [])
     {
         $this->broker->send($this->iopubSocket, 'status', ['execution_state' => 'busy'], $header);
 
@@ -56,7 +56,7 @@ final class KernelInfoAction implements Action
             ],
             $header,
             [],
-            $zmqId
+            $zmqIds
         );
 
         $this->broker->send($this->iopubSocket, 'status', ['execution_state' => 'idle'], $header);

--- a/src/Actions/ShutdownAction.php
+++ b/src/Actions/ShutdownAction.php
@@ -32,12 +32,12 @@ final class ShutdownAction implements Action
         $this->shellSocket = $shellSocket;
     }
 
-    public function call(array $header, array $content, $zmqId = null)
+    public function call(array $header, array $content, $zmqIds = [])
     {
         $this->broker->send($this->iopubSocket, 'status', ['execution_state' => 'busy'], $header);
 
         $replyContent = ['restart' => $content['restart']];
-        $this->broker->send($this->shellSocket, 'shutdown_reply', $replyContent, $header, [], $zmqId);
+        $this->broker->send($this->shellSocket, 'shutdown_reply', $replyContent, $header, [], $zmqIds);
 
         $this->broker->send($this->iopubSocket, 'status', ['execution_state' => 'idle'], $header);
     }

--- a/src/Handlers/ShellMessagesHandler.php
+++ b/src/Handlers/ShellMessagesHandler.php
@@ -67,8 +67,6 @@ final class ShellMessagesHandler
 
     public function __invoke(array $msg)
     {
-        $this->logger->debug('Received message');
-
         // Read ZMQ IDs until we reach the delimiter
         $zmqIds = array();
         while (!empty($msg)) {

--- a/src/Handlers/ShellMessagesHandler.php
+++ b/src/Handlers/ShellMessagesHandler.php
@@ -67,15 +67,25 @@ final class ShellMessagesHandler
 
     public function __invoke(array $msg)
     {
-        list($zmqId, $delim, $hmac, $header, $parentHeader, $metadata, $content) = $msg;
+        $this->logger->debug('Received message');
+
+        // Read ZMQ IDs until we reach the delimiter
+        $zmqIds = array();
+        while (!empty($msg)) {
+            $item = array_shift($msg);
+            if ($item === '<IDS|MSG>') break;
+            else array_push($zmqIds, $item);
+        }
+
+        // Read the remaining items
+        list($hmac, $header, $parentHeader, $metadata, $content) = $msg;
 
         $header = json_decode($header, true);
         $content = json_decode($content, true);
 
         $this->logger->debug('Received message', [
             'processId' => getmypid(),
-            'zmqId' => htmlentities($zmqId, ENT_COMPAT, "UTF-8"),
-            'delim' => $delim,
+            'zmqIds' => htmlentities(implode(", ", $zmqIds), ENT_COMPAT, "UTF-8"),
             'hmac' => $hmac,
             'header' => $header,
             'parentHeader' => $parentHeader,
@@ -84,13 +94,13 @@ final class ShellMessagesHandler
         ]);
 
         if ('kernel_info_request' === $header['msg_type']) {
-            $this->kernelInfoAction->call($header, $content, $zmqId);
+            $this->kernelInfoAction->call($header, $content, $zmqIds);
         } elseif ('execute_request' === $header['msg_type']) {
-            $this->executeAction->call($header, $content, $zmqId);
+            $this->executeAction->call($header, $content, $zmqIds);
         } elseif ('history_request' === $header['msg_type']) {
-            $this->historyAction->call($header, $content, $zmqId);
+            $this->historyAction->call($header, $content, $zmqIds);
         } elseif ('shutdown_request' === $header['msg_type']) {
-            $this->shutdownAction->call($header, $content, $zmqId);
+            $this->shutdownAction->call($header, $content, $zmqIds);
         } elseif ('comm_open' === $header['msg_type']) {
             // TODO: Research about what should be done.
         } else {

--- a/src/JupyterBroker.php
+++ b/src/JupyterBroker.php
@@ -51,7 +51,7 @@ final class JupyterBroker
         array $content = [],
         array $parentHeader = [],
         array $metadata = [],
-        $zmqId = null
+        $zmqIds = []
     ) {
         $header = $this->createHeader($msgType);
 
@@ -62,11 +62,7 @@ final class JupyterBroker
             json_encode(empty($content) ? new \stdClass : $content),
         ];
 
-        if (null !== $zmqId) {
-            $finalMsg = [$zmqId];
-        } else {
-            $finalMsg = [];
-        }
+        $finalMsg = $zmqIds;
 
         $finalMsg = array_merge(
             $finalMsg,


### PR DESCRIPTION

A ZMQ message may contain more than 1 ZMQ identifier; see the section on the Jupyter wire protocol here: https://jupyter-client.readthedocs.io/en/latest/messaging.html#the-wire-protocol. 

(This doesn't cause a problem with most Jupyter frontends, but I'm working on one it does cause an issue for.)